### PR TITLE
SEC-413: Pin github actions to commit hashes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,9 +7,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
           - name: Checkout repo
-            uses: actions/checkout@v3
+            uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
-          - uses: ruby/setup-ruby@v1
+          - uses: ruby/setup-ruby@1a615958ad9d422dd932dc1d5823942ee002799f # v1
             with:
               ruby-version: 2.7
               bundler-cache: true


### PR DESCRIPTION
SEC-413

Pin github actions to commit hashes. This is preventative remediation to avoid issues like the recent tj-actions supply chain attack as documented in https://www.wiz.io/blog/github-action-tj-actions-changed-files-supply-chain-attack-cve-2025-30066